### PR TITLE
EN-451: Update CODEOWNERS to quantum-infrastructure-reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @lukiffer @arledesma
+* @quantum-sec/quantum-infrastructure-reviewers


### PR DESCRIPTION
- [x] Set team @quantum-sec/quantum-infrastructure-reviewers to CODEOWNERS for repository